### PR TITLE
Make num_hashes more intuitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Running the program should produce a log similar to:
 
 ```rust
 Entry { num_hashes: 0, id: [0, ...], event: Tick }
-Entry { num_hashes: 2, id: [67, ...], event: Transaction { data: [37, ...] } }
+Entry { num_hashes: 3, id: [67, ...], event: Transaction { data: [37, ...] } }
 Entry { num_hashes: 3, id: [123, ...], event: Tick }
 ```
 

--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ fn main() {
 Running the program should produce a log similar to:
 
 ```rust
-Entry { num_hashes: 0, end_hash: [0, ...], event: Tick }
-Entry { num_hashes: 2, end_hash: [67, ...], event: Transaction { data: [37, ...] } }
-Entry { num_hashes: 3, end_hash: [123, ...], event: Tick }
+Entry { num_hashes: 0, id: [0, ...], event: Tick }
+Entry { num_hashes: 2, id: [67, ...], event: Transaction { data: [37, ...] } }
+Entry { num_hashes: 3, id: [123, ...], event: Tick }
 ```
 
 Proof-of-History
@@ -86,7 +86,7 @@ assert!(verify_slice(&entries, &seed));
 ```
 
 [It's a proof!](https://en.wikipedia.org/wiki/Curry–Howard_correspondence) For each entry returned by the
-historian, we can verify that `end_hash` is the result of applying a sha256 hash to the previous `end_hash`
+historian, we can verify that `id` is the result of applying a sha256 hash to the previous `id`
 exactly `num_hashes` times, and then hashing then event data on top of that. Because the event data is
 included in the hash, the events cannot be reordered without regenerating all the hashes.
 

--- a/diagrams/historian.msc
+++ b/diagrams/historian.msc
@@ -1,17 +1,17 @@
 msc {
   client,historian,logger;
 
-  logger=>historian [ label = "e0 = Entry{hash: h0, n: 0, event: Tick}" ] ;
+  logger=>historian [ label = "e0 = Entry{id: h0, n: 0, event: Tick}" ] ;
   logger=>logger [ label = "h1 = hash(h0)" ] ;
   logger=>logger [ label = "h2 = hash(h1)" ] ;
   client=>historian [ label = "Claim(d0)" ] ;
   historian=>logger [ label = "Claim(d0)" ] ;
   logger=>logger [ label = "h3 = hash(h2 + d0)" ] ;
-  logger=>historian [ label = "e1 = Entry{hash: hash(h3), n: 2, event: Claim(d0)}" ] ;
+  logger=>historian [ label = "e1 = Entry{id: hash(h3), n: 2, event: Claim(d0)}" ] ;
   logger=>logger [ label = "h4 = hash(h3)" ] ;
   logger=>logger [ label = "h5 = hash(h4)" ] ;
   logger=>logger [ label = "h6 = hash(h5)" ] ;
-  logger=>historian [ label = "e2 = Entry{hash: h6, n: 3, event: Tick}" ] ;
+  logger=>historian [ label = "e2 = Entry{id: h6, n: 3, event: Tick}" ] ;
   client=>historian [ label = "collect()" ] ;
   historian=>client [ label = "entries = [e0, e1, e2]" ] ;
   client=>client [ label = "verify_slice(entries, h0)" ] ;

--- a/diagrams/historian.msc
+++ b/diagrams/historian.msc
@@ -4,10 +4,10 @@ msc {
   logger=>historian [ label = "e0 = Entry{id: h0, n: 0, event: Tick}" ] ;
   logger=>logger [ label = "h1 = hash(h0)" ] ;
   logger=>logger [ label = "h2 = hash(h1)" ] ;
-  client=>historian [ label = "Claim(d0)" ] ;
-  historian=>logger [ label = "Claim(d0)" ] ;
+  client=>historian [ label = "Transaction(d0)" ] ;
+  historian=>logger [ label = "Transaction(d0)" ] ;
   logger=>logger [ label = "h3 = hash(h2 + d0)" ] ;
-  logger=>historian [ label = "e1 = Entry{id: hash(h3), n: 2, event: Claim(d0)}" ] ;
+  logger=>historian [ label = "e1 = Entry{id: hash(h3), n: 3, event: Transaction(d0)}" ] ;
   logger=>logger [ label = "h4 = hash(h3)" ] ;
   logger=>logger [ label = "h5 = hash(h4)" ] ;
   logger=>logger [ label = "h6 = hash(h5)" ] ;

--- a/src/accountant.rs
+++ b/src/accountant.rs
@@ -3,13 +3,15 @@
 //! transfer funds to other users.
 
 use log::{hash, Entry, Sha256Hash};
-use event::{Event, PublicKey, Signature};
+use event::{get_pubkey, sign_transaction_data, Event, PublicKey, Signature};
 use genesis::Genesis;
 use historian::Historian;
 use ring::signature::Ed25519KeyPair;
 use std::sync::mpsc::SendError;
 use std::collections::HashMap;
 use std::result;
+use std::thread::sleep;
+use std::time::Duration;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum AccountingError {
@@ -107,7 +109,6 @@ impl Accountant {
         keypair: &Ed25519KeyPair,
         to: PublicKey,
     ) -> Result<Signature> {
-        use event::{get_pubkey, sign_transaction_data};
         let from = get_pubkey(keypair);
         let sig = sign_transaction_data(&n, keypair, &to);
         let event = Event::Transaction {
@@ -124,8 +125,6 @@ impl Accountant {
     }
 
     pub fn wait_on_signature(self: &mut Self, wait_sig: &Signature) {
-        use std::thread::sleep;
-        use std::time::Duration;
         let mut entries = self.sync();
         let mut found = false;
         while !found {
@@ -147,6 +146,8 @@ mod tests {
     use event::{generate_keypair, get_pubkey};
     use logger::ExitReason;
     use genesis::Creator;
+    use std::thread::sleep;
+    use std::time::Duration;
 
     #[test]
     fn test_accountant() {
@@ -169,8 +170,6 @@ mod tests {
 
     #[test]
     fn test_invalid_transfer() {
-        use std::thread::sleep;
-        use std::time::Duration;
         let bob = Creator::new(1_000);
         let bob_pubkey = bob.pubkey;
         let alice = Genesis::new(11_000, vec![bob]);

--- a/src/accountant.rs
+++ b/src/accountant.rs
@@ -54,17 +54,6 @@ impl Accountant {
         entries
     }
 
-    pub fn deposit(self: &mut Self, n: u64, keypair: &Ed25519KeyPair) -> Result<Signature> {
-        use event::{get_pubkey, sign_claim_data};
-        let to = get_pubkey(keypair);
-        let sig = sign_claim_data(&n, keypair);
-        let event = Event::new_claim(to, n, sig);
-        if !self.historian.verify_event(&event) {
-            return Err(AccountingError::InvalidEvent);
-        }
-        self.process_verified_event(event, true).map(|_| sig)
-    }
-
     fn is_deposit(allow_deposits: bool, from: &PublicKey, to: &PublicKey) -> bool {
         allow_deposits && from == to
     }
@@ -210,9 +199,6 @@ mod tests {
         let mut acc = Accountant::new(&alice, Some(2));
         let alice_keypair = alice.get_keypair();
         let bob_keypair = generate_keypair();
-        let sig = acc.deposit(10_000, &alice_keypair).unwrap();
-        acc.wait_on_signature(&sig);
-
         let bob_pubkey = get_pubkey(&bob_keypair);
         let sig = acc.transfer(500, &alice_keypair, bob_pubkey).unwrap();
         acc.wait_on_signature(&sig);

--- a/src/accountant.rs
+++ b/src/accountant.rs
@@ -25,7 +25,7 @@ pub type Result<T> = result::Result<T, AccountingError>;
 pub struct Accountant {
     pub historian: Historian<u64>,
     pub balances: HashMap<PublicKey, u64>,
-    pub end_hash: Sha256Hash,
+    pub last_id: Sha256Hash,
 }
 
 impl Accountant {
@@ -35,7 +35,7 @@ impl Accountant {
         let mut acc = Accountant {
             historian: hist,
             balances: HashMap::new(),
-            end_hash: start_hash,
+            last_id: start_hash,
         };
         for (i, event) in gen.create_events().into_iter().enumerate() {
             acc.process_verified_event(event, i < 2).unwrap();
@@ -50,7 +50,7 @@ impl Accountant {
         }
 
         if let Some(last_entry) = entries.last() {
-            self.end_hash = last_entry.end_hash;
+            self.last_id = last_entry.id;
         }
 
         entries

--- a/src/accountant_skel.rs
+++ b/src/accountant_skel.rs
@@ -1,6 +1,8 @@
 use std::io;
 use accountant::Accountant;
 use event::{Event, PublicKey, Signature};
+use std::net::UdpSocket;
+use bincode::{deserialize, serialize};
 
 pub struct AccountantSkel {
     pub obj: Accountant,
@@ -60,8 +62,6 @@ impl AccountantSkel {
 
     /// UDP Server that forwards messages to Accountant methods.
     pub fn serve(self: &mut Self, addr: &str) -> io::Result<()> {
-        use std::net::UdpSocket;
-        use bincode::{deserialize, serialize};
         let socket = UdpSocket::bind(addr)?;
         let mut buf = vec![0u8; 1024];
         loop {

--- a/src/accountant_stub.rs
+++ b/src/accountant_stub.rs
@@ -5,7 +5,7 @@
 use std::net::UdpSocket;
 use std::io;
 use bincode::{deserialize, serialize};
-use event::{PublicKey, Signature};
+use event::{get_pubkey, sign_transaction_data, PublicKey, Signature};
 use ring::signature::Ed25519KeyPair;
 use accountant_skel::{Request, Response};
 
@@ -40,7 +40,6 @@ impl AccountantStub {
         keypair: &Ed25519KeyPair,
         to: PublicKey,
     ) -> io::Result<Signature> {
-        use event::{get_pubkey, sign_transaction_data};
         let from = get_pubkey(keypair);
         let sig = sign_transaction_data(&n, keypair, &to);
         self.transfer_signed(from, to, n, sig).map(|_| sig)

--- a/src/bin/client-demo.rs
+++ b/src/bin/client-demo.rs
@@ -1,19 +1,18 @@
 //extern crate serde_json;
 extern crate silk;
 
+use silk::accountant_stub::AccountantStub;
+use silk::accountant_skel::AccountantSkel;
+use silk::accountant::Accountant;
+use silk::event::{generate_keypair, get_pubkey, sign_transaction_data, verify_event, Event};
+use silk::genesis::Genesis;
+use std::time::Instant;
+use std::net::UdpSocket;
+use std::thread::{sleep, spawn};
+use std::time::Duration;
 //use std::io::stdin;
 
 fn main() {
-    use silk::accountant_stub::AccountantStub;
-    use silk::accountant_skel::AccountantSkel;
-    use silk::accountant::Accountant;
-    use silk::event::{generate_keypair, get_pubkey, sign_transaction_data};
-    use silk::genesis::Genesis;
-    use std::time::Instant;
-    use std::net::UdpSocket;
-    use std::thread::{sleep, spawn};
-    use std::time::Duration;
-
     let addr = "127.0.0.1:8000";
     let send_addr = "127.0.0.1:8001";
 
@@ -53,7 +52,6 @@ fn main() {
     );
 
     println!("Verify signatures...");
-    use silk::event::{verify_event, Event};
     let now = Instant::now();
     for &(k, s) in &sigs {
         let e = Event::Transaction {

--- a/src/bin/genesis-block.rs
+++ b/src/bin/genesis-block.rs
@@ -22,7 +22,7 @@ fn main() {
     drop(logger.sender);
 
     let entries = receiver.iter().collect::<Vec<_>>();
-    verify_slice_u64(&entries, &entries[0].end_hash);
+    verify_slice_u64(&entries, &entries[0].id);
     println!("[");
     let len = entries.len();
     for (i, x) in entries.iter().enumerate() {

--- a/src/event.rs
+++ b/src/event.rs
@@ -2,9 +2,9 @@
 //! an ordered log of events in time.
 
 /// Each log entry contains three pieces of data. The 'num_hashes' field is the number
-/// of hashes performed since the previous entry.  The 'end_hash' field is the result
-/// of hashing 'end_hash' from the previous entry 'num_hashes' times.  The 'event'
-/// field points to an Event that took place shortly after 'end_hash' was generated.
+/// of hashes performed since the previous entry.  The 'id' field is the result
+/// of hashing 'id' from the previous entry 'num_hashes' times.  The 'event'
+/// field points to an Event that took place shortly after 'id' was generated.
 ///
 /// If you divide 'num_hashes' by the amount of time it takes to generate a new hash, you
 /// get a duration estimate since the last event. Since processing power increases
@@ -27,7 +27,7 @@ pub type Signature = GenericArray<u8, U64>;
 /// When 'event' is Tick, the event represents a simple clock tick, and exists for the
 /// sole purpose of improving the performance of event log verification. A tick can
 /// be generated in 'num_hashes' hashes and verified in 'num_hashes' hashes.  By logging
-/// a hash alongside the tick, each tick and be verified in parallel using the 'end_hash'
+/// a hash alongside the tick, each tick and be verified in parallel using the 'id'
 /// of the preceding tick to seed its hashing.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub enum Event<T> {

--- a/src/event.rs
+++ b/src/event.rs
@@ -16,7 +16,10 @@
 use generic_array::GenericArray;
 use generic_array::typenum::{U32, U64};
 use ring::signature::Ed25519KeyPair;
+use ring::{rand, signature};
+use untrusted;
 use serde::Serialize;
+use bincode::serialize;
 
 pub type PublicKey = GenericArray<u8, U32>;
 pub type Signature = GenericArray<u8, U64>;
@@ -50,8 +53,6 @@ impl<T> Event<T> {
 
 /// Return a new ED25519 keypair
 pub fn generate_keypair() -> Ed25519KeyPair {
-    use ring::{rand, signature};
-    use untrusted;
     let rng = rand::SystemRandom::new();
     let pkcs8_bytes = signature::Ed25519KeyPair::generate_pkcs8(&rng).unwrap();
     signature::Ed25519KeyPair::from_pkcs8(untrusted::Input::from(&pkcs8_bytes)).unwrap()
@@ -64,7 +65,6 @@ pub fn get_pubkey(keypair: &Ed25519KeyPair) -> PublicKey {
 
 /// Return a signature for the given data using the private key from the given keypair.
 fn sign_serialized<T: Serialize>(data: &T, keypair: &Ed25519KeyPair) -> Signature {
-    use bincode::serialize;
     let serialized = serialize(data).unwrap();
     GenericArray::clone_from_slice(keypair.sign(&serialized).as_ref())
 }
@@ -86,8 +86,6 @@ pub fn sign_claim_data<T: Serialize>(data: &T, keypair: &Ed25519KeyPair) -> Sign
 
 /// Verify a signed message with the given public key.
 pub fn verify_signature(peer_public_key_bytes: &[u8], msg_bytes: &[u8], sig_bytes: &[u8]) -> bool {
-    use untrusted;
-    use ring::signature;
     let peer_public_key = untrusted::Input::from(peer_public_key_bytes);
     let msg = untrusted::Input::from(msg_bytes);
     let sig = untrusted::Input::from(sig_bytes);
@@ -102,7 +100,6 @@ pub fn get_signature<T>(event: &Event<T>) -> Option<Signature> {
 }
 
 pub fn verify_event<T: Serialize>(event: &Event<T>) -> bool {
-    use bincode::serialize;
     if let Event::Transaction {
         from,
         to,

--- a/src/historian.rs
+++ b/src/historian.rs
@@ -53,7 +53,7 @@ impl<T: 'static + Serialize + Clone + Debug + Send> Historian<T> {
                 if let Err(err) = logger.log_events(now, ms_per_tick) {
                     return err;
                 }
-                logger.end_hash = hash(&logger.end_hash);
+                logger.last_id = hash(&logger.last_id);
                 logger.num_hashes += 1;
             }
         })

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -8,7 +8,7 @@
 use std::collections::HashSet;
 use std::sync::mpsc::{Receiver, SyncSender, TryRecvError};
 use std::time::{Duration, Instant};
-use log::{hash_event, Entry, Sha256Hash};
+use log::{extend_and_hash, Entry, Sha256Hash};
 use event::{get_signature, verify_event, Event, Signature};
 use serde::Serialize;
 use std::fmt::Debug;
@@ -59,7 +59,9 @@ impl<T: Serialize + Clone + Debug> Logger<T> {
     }
 
     pub fn log_event(&mut self, event: Event<T>) -> Result<(), (Entry<T>, ExitReason)> {
-        self.last_id = hash_event(&self.last_id, &event);
+        if let Some(sig) = get_signature(&event) {
+            self.last_id = extend_and_hash(&self.last_id, &sig);
+        }
         let entry = Entry {
             id: self.last_id,
             num_hashes: self.num_hashes,

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -6,7 +6,7 @@
 //! The resulting stream of entries represents ordered events in time.
 
 use std::collections::HashSet;
-use std::sync::mpsc::{Receiver, SyncSender};
+use std::sync::mpsc::{Receiver, SyncSender, TryRecvError};
 use std::time::{Duration, Instant};
 use log::{hash_event, Entry, Sha256Hash};
 use event::{get_signature, verify_event, Event, Signature};
@@ -77,7 +77,6 @@ impl<T: Serialize + Clone + Debug> Logger<T> {
         epoch: Instant,
         ms_per_tick: Option<u64>,
     ) -> Result<(), (Entry<T>, ExitReason)> {
-        use std::sync::mpsc::TryRecvError;
         loop {
             if let Some(ms) = ms_per_tick {
                 if epoch.elapsed() > Duration::from_millis((self.num_ticks + 1) * ms) {

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -61,6 +61,7 @@ impl<T: Serialize + Clone + Debug> Logger<T> {
     pub fn log_event(&mut self, event: Event<T>) -> Result<(), (Entry<T>, ExitReason)> {
         if let Some(sig) = get_signature(&event) {
             self.last_id = extend_and_hash(&self.last_id, &sig);
+            self.num_hashes += 1;
         }
         let entry = Entry {
             id: self.last_id,


### PR DESCRIPTION
Before this change, num_hashes meant the number of hashes since
the last ID, minus any hashing done on the event data. It made
no difference for Tick events, but logged Transaction events with
one less hash than actually occurred.