### PR TITLE
Boot genesis block helper

### DIFF
--- a/src/bin/genesis-file-demo.rs
+++ b/src/bin/genesis-file-demo.rs
@@ -1,19 +1,28 @@
 extern crate serde_json;
 extern crate silk;
 
-use silk::genesis::{Creator, Genesis};
-use silk::signature::{generate_keypair, get_pubkey};
+use silk::genesis::Genesis;
+use silk::event::Event;
+use silk::transaction::Transaction;
+use silk::log::create_entries;
+use silk::signature::{generate_keypair, get_pubkey, KeyPair, PublicKey};
+use silk::hash::Hash;
+
+fn transfer(from: &KeyPair, (to, tokens): (PublicKey, i64), last_id: Hash) -> Event {
+    Event::Transaction(Transaction::new(&from, to, tokens, last_id))
+}
 
 fn main() {
-    let alice = Creator {
-        tokens: 200,
-        pubkey: get_pubkey(&generate_keypair()),
-    };
-    let bob = Creator {
-        tokens: 100,
-        pubkey: get_pubkey(&generate_keypair()),
-    };
-    let creators = vec![alice, bob];
-    let gen = Genesis::new(500, creators);
+    let alice = (get_pubkey(&generate_keypair()), 200);
+    let bob = (get_pubkey(&generate_keypair()), 100);
+
+    let gen = Genesis::new(500);
+    let from = gen.get_keypair();
+    let seed = gen.get_seed();
+    let mut events = gen.create_events();
+    events.push(transfer(&from, alice, seed));
+    events.push(transfer(&from, bob, seed));
+
+    create_entries(&seed, events);
     println!("{}", serde_json::to_string(&gen).unwrap());
 }

--- a/src/genesis.rs
+++ b/src/genesis.rs
@@ -2,7 +2,7 @@
 
 use event::Event;
 use transaction::Transaction;
-use signature::{generate_keypair, get_pubkey, PublicKey};
+use signature::{get_pubkey, PublicKey};
 use entry::Entry;
 use log::create_entries;
 use hash::{hash, Hash};
@@ -11,36 +11,16 @@ use ring::signature::Ed25519KeyPair;
 use untrusted::Input;
 
 #[derive(Serialize, Deserialize, Debug)]
-pub struct Creator {
-    pub pubkey: PublicKey,
-    pub tokens: i64,
-}
-
-impl Creator {
-    pub fn new(tokens: i64) -> Self {
-        Creator {
-            pubkey: get_pubkey(&generate_keypair()),
-            tokens,
-        }
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug)]
 pub struct Genesis {
     pub pkcs8: Vec<u8>,
     pub tokens: i64,
-    pub creators: Vec<Creator>,
 }
 
 impl Genesis {
-    pub fn new(tokens: i64, creators: Vec<Creator>) -> Self {
+    pub fn new(tokens: i64) -> Self {
         let rnd = SystemRandom::new();
         let pkcs8 = Ed25519KeyPair::generate_pkcs8(&rnd).unwrap().to_vec();
-        Genesis {
-            pkcs8,
-            tokens,
-            creators,
-        }
+        Genesis { pkcs8, tokens }
     }
 
     pub fn get_seed(&self) -> Hash {
@@ -55,23 +35,14 @@ impl Genesis {
         get_pubkey(&self.get_keypair())
     }
 
-    pub fn create_transaction(&self, asset: i64, to: &PublicKey) -> Event {
-        let tr = Transaction::new(&self.get_keypair(), *to, asset, self.get_seed());
-        Event::Transaction(tr)
-    }
-
     pub fn create_events(&self) -> Vec<Event> {
-        let pubkey = self.get_pubkey();
-        let event0 = Event::Tick;
-        let event1 = self.create_transaction(self.tokens, &pubkey);
-        let mut events = vec![event0, event1];
-
-        for x in &self.creators {
-            let tx = self.create_transaction(x.tokens, &x.pubkey);
-            events.push(tx);
-        }
-
-        events
+        let tr = Transaction::new(
+            &self.get_keypair(),
+            self.get_pubkey(),
+            self.tokens,
+            self.get_seed(),
+        );
+        vec![Event::Tick, Event::Transaction(tr)]
     }
 
     pub fn create_entries(&self) -> Vec<Entry> {
@@ -86,10 +57,10 @@ mod tests {
 
     #[test]
     fn test_create_events() {
-        let mut events = Genesis::new(100, vec![]).create_events().into_iter();
+        let mut events = Genesis::new(100).create_events().into_iter();
         assert_eq!(events.next().unwrap(), Event::Tick);
-        if let Event::Transaction(Transaction { from, to, .. }) = events.next().unwrap() {
-            assert_eq!(from, to);
+        if let Event::Transaction(tr) = events.next().unwrap() {
+            assert_eq!(tr.from, tr.to);
         } else {
             assert!(false);
         }
@@ -97,24 +68,8 @@ mod tests {
     }
 
     #[test]
-    fn test_create_creator() {
-        assert_eq!(
-            Genesis::new(100, vec![Creator::new(42)])
-                .create_events()
-                .len(),
-            3
-        );
-    }
-
-    #[test]
     fn test_verify_entries() {
-        let entries = Genesis::new(100, vec![]).create_entries();
-        assert!(verify_slice(&entries, &entries[0].id));
-    }
-
-    #[test]
-    fn test_verify_entries_with_transactions() {
-        let entries = Genesis::new(100, vec![Creator::new(42)]).create_entries();
+        let entries = Genesis::new(100).create_entries();
         assert!(verify_slice(&entries, &entries[0].id));
     }
 }

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -6,18 +6,19 @@ use ring::signature::Ed25519KeyPair;
 use ring::{rand, signature};
 use untrusted;
 
+pub type KeyPair = Ed25519KeyPair;
 pub type PublicKey = GenericArray<u8, U32>;
 pub type Signature = GenericArray<u8, U64>;
 
 /// Return a new ED25519 keypair
-pub fn generate_keypair() -> Ed25519KeyPair {
+pub fn generate_keypair() -> KeyPair {
     let rng = rand::SystemRandom::new();
     let pkcs8_bytes = signature::Ed25519KeyPair::generate_pkcs8(&rng).unwrap();
     signature::Ed25519KeyPair::from_pkcs8(untrusted::Input::from(&pkcs8_bytes)).unwrap()
 }
 
 /// Return the public key for the given keypair
-pub fn get_pubkey(keypair: &Ed25519KeyPair) -> PublicKey {
+pub fn get_pubkey(keypair: &KeyPair) -> PublicKey {
     GenericArray::clone_from_slice(keypair.public_key_bytes())
 }
 

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,7 +1,6 @@
 //! The `transaction` crate provides functionality for creating log transactions.
 
-use signature::{get_pubkey, verify_signature, PublicKey, Signature};
-use ring::signature::Ed25519KeyPair;
+use signature::{get_pubkey, verify_signature, KeyPair, PublicKey, Signature};
 use serde::Serialize;
 use bincode::serialize;
 use hash::Hash;
@@ -16,7 +15,7 @@ pub struct Transaction<T> {
 }
 
 impl<T: Serialize> Transaction<T> {
-    pub fn new(from_keypair: &Ed25519KeyPair, to: PublicKey, asset: T, last_id: Hash) -> Self {
+    pub fn new(from_keypair: &KeyPair, to: PublicKey, asset: T, last_id: Hash) -> Self {
         let mut tr = Transaction {
             from: get_pubkey(&from_keypair),
             to,
@@ -32,7 +31,7 @@ impl<T: Serialize> Transaction<T> {
         serialize(&(&self.from, &self.to, &self.asset, &self.last_id)).unwrap()
     }
 
-    pub fn sign(&mut self, keypair: &Ed25519KeyPair) {
+    pub fn sign(&mut self, keypair: &KeyPair) {
         let sign_data = self.get_sign_data();
         self.sig = Signature::clone_from_slice(keypair.sign(&sign_data).as_ref());
     }


### PR DESCRIPTION
Before this change, if you wanted to use a new Transaction
feature in the genesis block, you'd need to extend its
Creator object and associated methods.  With yesterday's
addtions to Transcation, it's now so easy to work with
Transactions directly that we can get rid of the middleman.

Also added a KeyPair type alias, so that ring could be easily swapped
out with a competing library, if needed.