### PR TITLE
Deterministic historian/accountant hashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,7 +355,7 @@ dependencies = [
 
 [[package]]
 name = "silk"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "bincode 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "silk"
 description = "A silky smooth implementation of the Loom architecture"
-version = "0.3.2"
+version = "0.3.3"
 documentation = "https://docs.rs/silk"
 homepage = "http://loomprotocol.com/"
 repository = "https://github.com/loomprotocol/silk"

--- a/src/historian.rs
+++ b/src/historian.rs
@@ -48,8 +48,10 @@ impl Historian {
                 if let Err(err) = logger.process_events(now, ms_per_tick) {
                     return err;
                 }
-                logger.last_id = hash(&logger.last_id);
-                logger.num_hashes += 1;
+                if ms_per_tick.is_some() {
+                    logger.last_id = hash(&logger.last_id);
+                    logger.num_hashes += 1;
+                }
             }
         })
     }
@@ -85,6 +87,10 @@ mod tests {
         let entry0 = hist.receiver.recv().unwrap();
         let entry1 = hist.receiver.recv().unwrap();
         let entry2 = hist.receiver.recv().unwrap();
+
+        assert_eq!(entry0.num_hashes, 0);
+        assert_eq!(entry1.num_hashes, 0);
+        assert_eq!(entry2.num_hashes, 0);
 
         drop(hist.sender);
         assert_eq!(


### PR DESCRIPTION
When in tick-less mode, no longer continuously hash on the
background thread. That mode is just used for testing and
genesis log generation, and those extra hashes are just noise.

Note that without the extra hashes, with lose the duration between
events. Effectively, we distinguish proof-of-order from proof-of-time.