### PR TITLE
WIP: Entry-level smart contracts

### DIFF
--- a/src/accountant.rs
+++ b/src/accountant.rs
@@ -109,12 +109,13 @@ impl Accountant {
 
     /// Commit funds to the 'to' party.
     fn complete_transaction(self: &mut Self, tr: &Transaction<i64>) {
-        if self.balances.contains_key(&tr.plan.to) {
-            if let Some(x) = self.balances.get_mut(&tr.plan.to) {
+        let to = tr.plan.to();
+        if self.balances.contains_key(&to) {
+            if let Some(x) = self.balances.get_mut(&to) {
                 *x += tr.asset;
             }
         } else {
-            self.balances.insert(tr.plan.to, tr.asset);
+            self.balances.insert(to, tr.asset);
         }
     }
 
@@ -149,17 +150,17 @@ impl Accountant {
             return Err(AccountingError::InvalidTransferSignature);
         }
 
-        if !tr.plan.unless_any.is_empty() {
+        if !tr.plan.unless_any.0.is_empty() {
             // TODO: Check to see if the transaction is expired.
         }
 
-        if !Self::is_deposit(allow_deposits, &tr.from, &tr.plan.to) {
+        if !Self::is_deposit(allow_deposits, &tr.from, &tr.plan.to()) {
             if let Some(x) = self.balances.get_mut(&tr.from) {
                 *x -= tr.asset;
             }
         }
 
-        if !self.all_satisfied(&tr.plan.if_all) {
+        if !self.all_satisfied(&tr.plan.if_all.0) {
             self.pending.insert(tr.sig, tr.clone());
             return Ok(());
         }
@@ -175,7 +176,7 @@ impl Accountant {
             // if Signature(from) is in unless_any, return funds to tx.from, and remove the tx from this map.
 
             // TODO: Use find().
-            for cond in &tr.plan.unless_any {
+            for cond in &tr.plan.unless_any.0 {
                 if let Condition::Signature(pubkey) = *cond {
                     if from == pubkey {
                         cancel = true;
@@ -220,17 +221,17 @@ impl Accountant {
         // Check to see if any timelocked transactions can be completed.
         let mut completed = vec![];
         for (key, tr) in &self.pending {
-            for cond in &tr.plan.if_all {
+            for cond in &tr.plan.if_all.0 {
                 if let Condition::Timestamp(dt) = *cond {
                     if self.last_time >= dt {
-                        if tr.plan.if_all.len() == 1 {
+                        if tr.plan.if_all.0.len() == 1 {
                             completed.push(*key);
                         }
                     }
                 }
             }
             // TODO: Add this in once we start removing constraints
-            //if tr.plan.if_all.is_empty() {
+            //if tr.plan.if_all.0.is_empty() {
             //    // TODO: Remove tr from pending
             //    self.complete_transaction(tr);
             //}

--- a/src/mint.rs
+++ b/src/mint.rs
@@ -63,7 +63,7 @@ mod tests {
     fn test_create_events() {
         let mut events = Mint::new(100).create_events().into_iter();
         if let Event::Transaction(tr) = events.next().unwrap() {
-            assert_eq!(tr.from, tr.to);
+            assert_eq!(tr.from, tr.plan.to);
         }
         assert_eq!(events.next(), None);
     }

--- a/src/mint.rs
+++ b/src/mint.rs
@@ -58,12 +58,15 @@ impl Mint {
 mod tests {
     use super::*;
     use log::verify_slice;
+    use transaction::{Action, Plan};
 
     #[test]
     fn test_create_events() {
         let mut events = Mint::new(100).create_events().into_iter();
         if let Event::Transaction(tr) = events.next().unwrap() {
-            assert_eq!(tr.from, tr.plan.to());
+            if let Plan::Action(Action::Pay(payment)) = tr.plan {
+                assert_eq!(tr.from, payment.to);
+            }
         }
         assert_eq!(events.next(), None);
     }

--- a/src/mint.rs
+++ b/src/mint.rs
@@ -63,7 +63,7 @@ mod tests {
     fn test_create_events() {
         let mut events = Mint::new(100).create_events().into_iter();
         if let Event::Transaction(tr) = events.next().unwrap() {
-            assert_eq!(tr.from, tr.plan.to);
+            assert_eq!(tr.from, tr.plan.to());
         }
         assert_eq!(events.next(), None);
     }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -24,12 +24,12 @@ pub struct Payment<T> {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
-pub struct SpendingPlan<T> {
+pub struct Plan<T> {
     pub if_all: (Vec<Condition>, Action<T>),
     pub unless_any: (Vec<Condition>, Action<T>),
 }
 
-impl<T> SpendingPlan<T> {
+impl<T> Plan<T> {
     pub fn to(&self) -> PublicKey {
         let Action::Pay(ref payment) = self.if_all.1;
         payment.to
@@ -39,7 +39,7 @@ impl<T> SpendingPlan<T> {
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct Transaction<T> {
     pub from: PublicKey,
-    pub plan: SpendingPlan<T>,
+    pub plan: Plan<T>,
     pub asset: T,
     pub last_id: Hash,
     pub sig: Signature,
@@ -48,7 +48,7 @@ pub struct Transaction<T> {
 impl<T: Serialize + Clone> Transaction<T> {
     pub fn new(from_keypair: &KeyPair, to: PublicKey, asset: T, last_id: Hash) -> Self {
         let from = from_keypair.pubkey();
-        let plan = SpendingPlan {
+        let plan = Plan {
             if_all: (
                 vec![],
                 Action::Pay(Payment {
@@ -83,7 +83,7 @@ impl<T: Serialize + Clone> Transaction<T> {
         last_id: Hash,
     ) -> Self {
         let from = from_keypair.pubkey();
-        let plan = SpendingPlan {
+        let plan = Plan {
             if_all: (
                 vec![Condition::Timestamp(dt)],
                 Action::Pay(Payment {
@@ -159,7 +159,7 @@ mod tests {
 
     #[test]
     fn test_serialize_claim() {
-        let plan = SpendingPlan {
+        let plan = Plan {
             if_all: (
                 Default::default(),
                 Action::Pay(Payment {

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -57,7 +57,7 @@ impl<T: Serialize + Clone> Transaction<T> {
                 }),
             ),
             unless_any: (
-                vec![],
+                vec![Condition::Signature(from)],
                 Action::Pay(Payment {
                     asset: asset.clone(),
                     to: from,


### PR DESCRIPTION
About the same "contract" functionality as before (same test suite anyway), but now tucked away in a declarative data structure.

The codebase expanded a bit to get here, but much of the accountant will be able to collapse via recursive functions, and the completed/canceled functions will be unified. Also, a lot of the functionality that's in the accountant will be able to move into the transaction crate, and that crate will likely be split into two. Defining and interpreting the smart contracts can stand on its own.